### PR TITLE
Permalink is displayed after deployment (along with the alias URL).

### DIFF
--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -133,7 +133,8 @@ exports.cmd = function(config, cmd) {
             console.log("\nDraft deploy " + chalk.bold(deploy.id) + ":\n  " + chalk.bold(deploy.deploy_url));
             process.exit(0);
           } else {
-            console.log("\nDeploy is live:\n  " + chalk.bold(deploy.url));
+            console.log("\nDeploy is live (permalink):\n  " + chalk.bold(deploy.deploy_url));
+            console.log("\nLast build is always accessible on " + chalk.bold(deploy.url));
             process.exit(0);
           }
         });


### PR DESCRIPTION
Useful when working on several features that must be tested separately. It cuts the need to go to the *Build* page on the site to get the unique URL.