### PR TITLE
Add "env" command

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,6 +13,7 @@ var program    = require("commander"),
     list       = require("../lib/commands/list_sites"),
     updateSite = require("../lib/commands/update_site"),
     openSite   = require("../lib/commands/open"),
+    env        = require("../lib/commands/env"),
     updateNotifier = require('update-notifier'),
     pkg = require('../package.json');
 
@@ -76,6 +77,13 @@ program
   .command("init")
   .description("Configure continuous deployment")
   .action(config.wrap(program, init.cmd));
+
+program
+  .command("env")
+  .description("Output configured env variables")
+  .option("-s --site-id [id]", "Fetch from site with <id>")
+  .option("-f --file [filename]", "Save to file called <filename>")
+  .action(config.wrap(program, env.cmd));
 
 program
   .command("*","",{noHelp: true})

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -67,7 +67,7 @@ function sanityCheck(config) {
 
 exports.cmd = function(config, cmd) {
   var siteId     = config.getSiteId(cmd),
-      siePromise = null;
+      sitePromise = null;
 
   if (siteId) {
     sitePromise = config.client.site(siteId);

--- a/lib/commands/env.js
+++ b/lib/commands/env.js
@@ -1,0 +1,43 @@
+var chalk       = require("chalk"),
+    inquirer    = require("inquirer"),
+    when        = require("when"),
+    fn          = require("when/callbacks"),
+    fs          = require("fs"),
+    confirm     = require("../helpers/confirm"),
+    site_picker = require("../helpers/site_picker"),
+    errorLogger = require("../helpers/error_logger");
+
+exports.cmd = function(config, cmd) {
+    var siteId      = config.getSiteId(cmd),
+        sitePromise = null,
+        file        = cmd.file;
+
+    if (siteId) {
+        sitePromise = config.client.site(siteId);
+    } else {
+        sitePromise = site_picker.pickSite(config.client, {});
+    }
+
+    sitePromise
+        .then(function(site) {
+            const envVars = site.build_settings.env;
+            const envContents = Object.keys(envVars).map(function(key) {
+                return key + '="' + envVars[key] + '"';
+            }).join('\n');
+
+            if(file) {
+                fs.writeFile(file, envContents, function(err) {
+                    if(err) {
+                        console.error("Could not save file.");
+                        process.exit(1);
+                    } else {
+                        console.log("Saved to " + chalk.bold(file));
+                        process.exit(0);
+                    }
+                });
+            } else {
+                console.log(envContents);
+                process.exit(0);
+            }
+        });
+};


### PR DESCRIPTION
*Improvement of developer experience*

This command takes the environment variables from netlify and writes them either to stdout or to a file.
It should be especially useful for people using dotenv locally, because the output uses dotenv compatible syntax.