### PR TITLE
Prevent global and local config paths to clash

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ Netlify creates different sites with each their own URL for each of your environ
 - netlify-cli is known to hang with an "ECONNRESET" error (parsed as JSON, it will look odd) when used from many CI environments.  This is a known issue that is only fixed in our alternate and current CLI:  https://github.com/netlify/netlifyctl
 
 - netlify-cli is known to hang when used with Node.js version 8.1.0.  Version 8.1.2 works well
+
+- the local config file is named `.netlify.local` instead of `.netlify` when you run commands from within your home directory.

--- a/lib/settings/config.js
+++ b/lib/settings/config.js
@@ -9,9 +9,11 @@ var when    = require("when"),
 var CLIENT_ID         = process.env.NETLIFY_CLIENT_ID || "5edad8f69d47ae8923d0cf0b4ab95ba1415e67492b5af26ad97f4709160bb31b",
     API_ENDPOINT      = process.env.NETLIFY_ENDPOINT,
     PREVIEW_DOMAIN    = process.env.NETLIFY_PREVIEW_DOMAIN || "netlify.com",
-    CONFIG_DIR        = path.join(homeDir(), '.netlify'),
+    HOME_DIR          = homeDir(),
+    CURRENT_DIR       = process.cwd(),
+    CONFIG_DIR        = path.join(HOME_DIR, '.netlify'),
     CONFIG_PATH       = path.join(CONFIG_DIR, "config"),
-    LOCAL_CONFIG_PATH = path.join(process.cwd(), ".netlify");
+    LOCAL_CONFIG_PATH = path.join(CURRENT_DIR, CURRENT_DIR === HOME_DIR ? ".netlify.local" : ".netlify");
 
 var readLocalConfig = function(env) {
   if (fs.existsSync(LOCAL_CONFIG_PATH)) {


### PR DESCRIPTION
Fix #32.

Currently, calling `netlify` commands from within the home directory will crash because `netlify` first saves the *global* config at `~/.netlify/config` (so `~/.netlify/` is a directory) and then try to save the *local* config at `~/.netlify` (as a file).

With this PR, if the CLI detects that the command is ran from the home directory, it will save the local config as `.netlify.local` instead of `.netlify` to prevent the names from clashing. In any other cases, it keeps the existing `.netlify` to allow backward compatibility.

Another approach would be to allow the local config file name to be overwritten via environment variable (e.g. `LOCAL_CONFIG_FILENAME`), the same way it is already possible some other options. Note that it would mean that the user has to first encounter the error, learn about such setting and then use it. On the other hand, with the change from this PR, the CLI will work automatically.