### PR TITLE
Fix authentication prompt typo

### DIFF
--- a/lib/helpers/webui.js
+++ b/lib/helpers/webui.js
@@ -12,7 +12,7 @@ exports.open = function(path) {
   return when.promise(function(resolve, reject) {
     p.on('exit', function(code) {
       if (parseInt(code) > 0) {
-        console.log("Please visite this authentication URL in your browser:\n  " + chalk.bold(url));
+        console.log("Please visit this authentication URL in your browser:\n  " + chalk.bold(url));
       }
       else {
         console.log('Opening ' + chalk.bold(url));


### PR DESCRIPTION
**- Summary**

Fixes a typo in the authentication prompt. 

**- Test plan**

Prompt should be 'Please visit this authentication', not 'Please visite this authentication'.

**- Description for the changelog**

Fixes authentication prompt typo